### PR TITLE
Fix KeyError 'result'

### DIFF
--- a/gocd_cli/commands/pipeline/__init__.py
+++ b/gocd_cli/commands/pipeline/__init__.py
@@ -102,7 +102,7 @@ class Trigger(BaseCommand):
 
     def _stages_finished(self, response):
         for stage in response['stages']:
-            if stage['result'] not in self.pipeline.final_results:
+            if stage.get('result') not in self.pipeline.final_results:
                 return False
 
         return True


### PR DESCRIPTION
There is a specific point of time where Go server API does not return `'result'` for `stage` object in JSON response body.
See https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/rails.new/app/models/stage_instance_api_model.rb#L26
In order to prevent KeyError, we should use `.get()` instead of `[]` to read `'result'` from the `stage` dictionary.

cc: @chuajiesheng
